### PR TITLE
JASSISTANT-121: Fix issue bean properties

### DIFF
--- a/helm/jassistant/templates/deployment.yaml
+++ b/helm/jassistant/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               path: /
               port: http
           readinessProbe:
+            initialDelaySeconds: 60
+            periodSeconds: 10
             httpGet:
               path: /
               port: http

--- a/jira-assistant-billing/src/main/java/net/netconomy/jiraassistant/billing/data/BillingIssue.java
+++ b/jira-assistant-billing/src/main/java/net/netconomy/jiraassistant/billing/data/BillingIssue.java
@@ -25,15 +25,11 @@ import net.netconomy.jiraassistant.base.data.SingleTimeMetric;
 
 public class BillingIssue extends IssueLight {
 	
-    private String priority = "";
     private List<String> components = new ArrayList<>();
     private String reporter = "";
 
     private String epicKey = "";
     private String epicName = "";
-
-    private String accountKey = "";
-    private String accountName = "";
 
     private List<String> linkedIssuesKeysToList = new ArrayList<>();
 
@@ -108,22 +104,6 @@ public class BillingIssue extends IssueLight {
         this.personDaysEstimated = personDaysEstimated;
     }
 
-    public String getAccountKey() {
-        return accountKey;
-    }
-
-    public void setAccountKey(String accountKey) {
-        this.accountKey = accountKey;
-    }
-
-    public String getAccountName() {
-        return accountName;
-    }
-
-    public void setAccountName(String accountName) {
-        this.accountName = accountName;
-    }
-
     public String getEpicKey() {
         return epicKey;
     }
@@ -146,16 +126,6 @@ public class BillingIssue extends IssueLight {
 
     public void setLinkedIssuesKeysToList(List<String> linkedIssuesKeysToList) {
         this.linkedIssuesKeysToList = linkedIssuesKeysToList;
-    }
-
-    @Override
-    public String getPriority() {
-        return priority;
-    }
-
-    @Override
-    public void setPriority(String priority) {
-        this.priority = priority;
     }
 
     public List<String> getComponents() {
@@ -209,13 +179,13 @@ public class BillingIssue extends IssueLight {
     @Override
     public String toString() {
         return "BillingIssue{" +
-                "priority='" + priority + '\'' +
+                "priority='" + this.getPriority() + '\'' +
                 ", components=" + components +
                 ", reporter='" + reporter + '\'' +
                 ", epicKey='" + epicKey + '\'' +
                 ", epicName='" + epicName + '\'' +
-                ", accountKey='" + accountKey + '\'' +
-                ", accountName='" + accountName + '\'' +
+                ", accountKey='" + this.getAccountKey() + '\'' +
+                ", accountName='" + this.getAccountName() + '\'' +
                 ", linkedIssuesKeysToList=" + linkedIssuesKeysToList +
                 ", bookedTimeInTimeFrameMinutes=" + bookedTimeInTimeFrameMinutes +
                 ", originalEstimateMinutes=" + originalEstimateMinutes +

--- a/jira-assistant-restservices/src/main/resources/logback.xml
+++ b/jira-assistant-restservices/src/main/resources/logback.xml
@@ -30,12 +30,12 @@
     </appender>
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
         <Target>System.out</Target>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n</pattern>
-        </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
         </filter>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n</pattern>
+        </encoder>
     </appender>
     <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
         <dsn>${RAVEN_DSN}</dsn>
@@ -45,7 +45,7 @@
             <level>WARN</level>
         </filter>
     </appender>
-    <root level="ALL">
+    <root level="DEBUG">
     	<appender-ref ref="file"/>
     	<appender-ref ref="stdout"/>
     	<appender-ref ref="Sentry"/>


### PR DESCRIPTION
`priority`, `accountKey`, and `accountName` are already present in the base-class. Without an @override or something similar this caused a serialization error.

Additionally, this decreases the default loglevel to something less noisy.